### PR TITLE
Improvements for CMS PR 40373

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -994,6 +994,7 @@ class Indexer
                 $db->execute();
             } catch (\Joomla\Database\Exception\ExecutionFailureException $e) {
                 $supported = false;
+                return true;
             }
 
             // Set the internal state.

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -974,6 +974,7 @@ class Indexer
 
         if (strtolower($this->db->getServerType()) != 'mysql') {
             $supported = false;
+
             return true;
         }
 
@@ -994,6 +995,7 @@ class Indexer
                 $db->execute();
             } catch (\Joomla\Database\Exception\ExecutionFailureException $e) {
                 $supported = false;
+
                 return true;
             }
 

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -966,9 +966,9 @@ class Indexer
      */
     protected function toggleTables($memory)
     {
-        static $supported;
+        static $supported = true;
 
-        if (is_bool($supported) && !$supported) {
+        if (!$supported) {
             return true;
         }
 
@@ -992,8 +992,6 @@ class Indexer
                 // Set the tokens aggregate table to Memory.
                 $db->setQuery('ALTER TABLE ' . $db->quoteName('#__finder_tokens_aggregate') . ' ENGINE = MEMORY');
                 $db->execute();
-
-                $supported = true;
             } catch (\Joomla\Database\Exception\ExecutionFailureException $e) {
                 $supported = false;
             }


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/40373 .

### Summary of Changes

1. Simplify code by initializing the static `$supported` variable to `true` so it doesn't need the `is_bool` check at the top and later below the `$supported = true;`.
2. Return when an exception was caught so the `$state` variable is not set to the wrong value later below.
3. Code style: When we have a `return` statement, and in the same code block we have statements before that, we should have an empty line before the `return` statement.

### Testing Instructions

Code review.

Or real test: Check if it works the same with and without my changes regarding the issue referred by the CMS PR.